### PR TITLE
Alpha4

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -730,9 +730,9 @@
       #define DEFAULT_Ki 5.530
       #define DEFAULT_Kd 35.961
 	#else
-        #define DEFAULT_Kp  22.20
-        #define DEFAULT_Ki   1.08
-        #define DEFAULT_Kd 114.00	
+        #define DEFAULT_Kp  15.33
+        #define DEFAULT_Ki   2.99
+        #define DEFAULT_Kd  19.63	
 	#endif
   #endif
 #else
@@ -1365,7 +1365,7 @@
   #define DEFAULT_MAX_ACCELERATION      { 3000, 3000, 1000, 5000 }
  // #define DEFAULT_MAX_ACCELERATION      { 10000, 10000, 1000, 5000 }
 #elif defined(ENV_ALPHA3) || defined(ENV_ALPHA4)
-  #define DEFAULT_MAX_ACCELERATION      { 5000, 5000, 100, 5000 }
+  #define DEFAULT_MAX_ACCELERATION      { 5000, 5000, 1000, 3000 }
 #else 
   #define DEFAULT_MAX_ACCELERATION      { 3000, 3000, 100, 10000 }
 #endif
@@ -1736,7 +1736,7 @@
 
 // X and Y axis travel speed between probes.
 // Leave undefined to use the average of the current XY homing feedrate.
-#define XY_PROBE_FEEDRATE    (50*60) // (mm/min)
+#define XY_PROBE_FEEDRATE    (60*60) // (mm/min)
 
 // Feedrate for the first approach when double-probing (MULTIPLE_PROBING == 2)
 #define Z_PROBE_FEEDRATE_FAST  (10*60) // (mm/min)
@@ -2308,7 +2308,7 @@
    * at which point movement will be level to the machine's XY plane.
    * The height can be set with M420 Z<height>
    */
-  #define ENABLE_LEVELING_FADE_HEIGHT
+  // #define ENABLE_LEVELING_FADE_HEIGHT
   #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
     // Toybox Alex: This shouldn't be to low. Setting it to low will cause the nozzle
     // to grind against the print.
@@ -2325,7 +2325,7 @@
    * contours of the bed more closely than edge-to-edge straight moves.
    */
   #define SEGMENT_LEVELED_MOVES
-  #define LEVELED_SEGMENT_LENGTH 5.0 // (mm) Length of all segments (except the last one)
+  #define LEVELED_SEGMENT_LENGTH 5 // (mm) Length of all segments (except the last one)
 
   /**
    * Enable the G26 Mesh Validation Pattern tool.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -729,11 +729,20 @@
       #define DEFAULT_Kp 28.205
       #define DEFAULT_Ki 5.530
       #define DEFAULT_Kd 35.961
-	#else
-        #define DEFAULT_Kp  15.33
-        #define DEFAULT_Ki   2.99
-        #define DEFAULT_Kd  19.63	
-	#endif
+	  #elif defined(ENV_ALPHA3)
+      #define DEFAULT_Kp  22.20
+      #define DEFAULT_Ki   1.08
+      #define DEFAULT_Kd 114.00
+    #elif defined(ENV_ALPHA4)
+      #define DEFAULT_Kp  15.33
+      #define DEFAULT_Ki   2.99
+      #define DEFAULT_Kd  19.63
+	  #else
+      // defaults
+      #define DEFAULT_Kp  22.20
+      #define DEFAULT_Ki   1.08
+      #define DEFAULT_Kd 114.00	
+	  #endif
   #endif
 #else
   #define BANG_MAX 255    // Limit hotend current while in bang-bang mode; 255=full current
@@ -1364,7 +1373,9 @@
 #ifdef ENV_CHARLIE
   #define DEFAULT_MAX_ACCELERATION      { 3000, 3000, 1000, 5000 }
  // #define DEFAULT_MAX_ACCELERATION      { 10000, 10000, 1000, 5000 }
-#elif defined(ENV_ALPHA3) || defined(ENV_ALPHA4)
+#elif defined(ENV_ALPHA3)
+  #define DEFAULT_MAX_ACCELERATION      { 5000, 5000, 1000, 3000 }
+#elif defined(ENV_ALPHA4)
   #define DEFAULT_MAX_ACCELERATION      { 5000, 5000, 1000, 3000 }
 #else 
   #define DEFAULT_MAX_ACCELERATION      { 3000, 3000, 100, 10000 }
@@ -1732,7 +1743,7 @@
 #endif
 
 
-#ifdef ENV_ALPHA4
+#ifdef ENV_ALPHA4 //ALPHA3 does not require a probe
 
 // X and Y axis travel speed between probes.
 // Leave undefined to use the average of the current XY homing feedrate.
@@ -2308,16 +2319,20 @@
    * at which point movement will be level to the machine's XY plane.
    * The height can be set with M420 Z<height>
    */
-  // #define ENABLE_LEVELING_FADE_HEIGHT
+  #ifndef ENV_ALPHA4
+    #define ENABLE_LEVELING_FADE_HEIGHT
+  #endif
+     
+  // Toybox Alex: This shouldn't be to low. Setting it to low will cause the nozzle
+  // to grind against the print.
+
   #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-    // Toybox Alex: This shouldn't be to low. Setting it to low will cause the nozzle
-    // to grind against the print.
     #ifdef ENV_ALPHA4
       #define DEFAULT_LEVELING_FADE_HEIGHT 25.0
-    #else
+    #else        
       #define DEFAULT_LEVELING_FADE_HEIGHT 15.0
-    #endif
-  #endif
+    #endif  
+  #endif  
 
   /**
    * For Cartesian machines, instead of dividing moves on mesh boundaries,

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2365,20 +2365,25 @@
 #define LIN_ADVANCE
 
 #if ENABLED(LIN_ADVANCE)
-#ifdef ENV_CHARLIE
-
-  #if ENABLED(DISTINCT_E_FACTORS)
-    #define ADVANCE_K { 0.03 }    // (mm) Compression length per 1mm/s extruder speed, per extruder
-  #else
-    #define ADVANCE_K 0.03        // (mm) Compression length applying to all extruders
-  #endif
+  #ifdef ENV_CHARLIE
+    #if ENABLED(DISTINCT_E_FACTORS)
+      #define ADVANCE_K { 0.03 }    // (mm) Compression length per 1mm/s extruder speed, per extruder
+    #else
+      #define ADVANCE_K 0.03        // (mm) Compression length applying to all extruders
+    #endif
+  #elif defined(ENV_ALPHA4)
+    #if ENABLED(DISTINCT_E_FACTORS)
+      #define ADVANCE_K { 0.03 }
+    #else
+      #define ADVANCE_K 0.02
+    #endif  
   #else 
     #if ENABLED(DISTINCT_E_FACTORS)
-    #define ADVANCE_K { 0.03 }    // (mm) Compression length per 1mm/s extruder speed, per extruder
-  #else
-    #define ADVANCE_K 0.018        // (mm) Compression length applying to all extruders
+      #define ADVANCE_K { 0.03 }    // (mm) Compression length per 1mm/s extruder speed, per extruder
+    #else
+      #define ADVANCE_K 0.03        // (mm) Compression length applying to all extruders
+    #endif
   #endif
-#endif
 
   //#define ADVANCE_K_EXTRA       // Add a second linear advance constant, configurable with M900 L.
   //#define LA_DEBUG              // Print debug information to serial during operation. Disable for production use.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2376,7 +2376,7 @@
     #if ENABLED(DISTINCT_E_FACTORS)
     #define ADVANCE_K { 0.03 }    // (mm) Compression length per 1mm/s extruder speed, per extruder
   #else
-    #define ADVANCE_K 0.03        // (mm) Compression length applying to all extruders
+    #define ADVANCE_K 0.018        // (mm) Compression length applying to all extruders
   #endif
 #endif
 

--- a/Marlin/src/HAL/HC32/HAL.cpp
+++ b/Marlin/src/HAL/HC32/HAL.cpp
@@ -54,3 +54,7 @@ extern "C" void core_hook_usart_rx_irq(uint8_t ch, uint8_t usart) {
 
 #endif // EMERGENCY_PARSER
 #endif // ARDUINO_ARCH_HC32
+
+extern "C" void __attribute__((constructor)) _enable_fpu() {
+    SCB->CPACR |= 0x00F00000;   // 直接使能 FPU
+}

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -690,7 +690,9 @@ cleanup:
 
   TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(old_grblstate));
 
+  #if defined(ENV_ALPHA4)
   cs1237.homing_flg = 0;
+  #endif
 
   #if ENABLED(TOYBOX_FAST_CMDS)
     if(stop_running_move){

--- a/buildroot/share/PlatformIO/scripts/hc32fpu.py
+++ b/buildroot/share/PlatformIO/scripts/hc32fpu.py
@@ -1,0 +1,9 @@
+# hc32fpu.py
+Import("env")
+
+fpuFlags = [
+    "-mfloat-abi=hard",
+    "-mfpu=fpv4-sp-d16"
+]
+
+env.Append(CCFLAGS=fpuFlags, LINKFLAGS=fpuFlags)

--- a/ini/hc32.ini
+++ b/ini/hc32.ini
@@ -112,6 +112,11 @@ board_build.ddl.interrupts = true
 #debug_tool = cmsis-dap
 monitor_speed               = 115200
 debug_tool  = jlink
+build_flags = 
+    -D __FPU_PRESENT=1
+    -D __FPU_USED=1
+    -mfloat-abi=hard
+    -mfpu=fpv4-sp-d16
 
 
 #

--- a/ini/hc32.ini
+++ b/ini/hc32.ini
@@ -69,6 +69,8 @@ board_build.flags.cpp = -fno-threadsafe-statics  # Disable thread-safe statics (
 [HC32F460C_base]
 extends = HC32F460_base
 board_upload.maximum_size = 262144
+extra_scripts = ${common.extra_scripts}
+    pre:buildroot/share/PlatformIO/scripts/hc32fpu.py
 
 #
 # Base HC32F460xExx (512K Flash)
@@ -112,11 +114,6 @@ board_build.ddl.interrupts = true
 #debug_tool = cmsis-dap
 monitor_speed               = 115200
 debug_tool  = jlink
-build_flags = 
-    -D __FPU_PRESENT=1
-    -D __FPU_USED=1
-    -mfloat-abi=hard
-    -mfpu=fpv4-sp-d16
 
 
 #

--- a/platformio.ini
+++ b/platformio.ini
@@ -147,16 +147,27 @@ monitor_filters   = colorize, time, send_on_enter
 
 [env:Alpha4]
 extends = env:HC32F460C_ASD_HC_V2_4
-build_flags   = -D ENV_ALPHA4  
+build_flags = 
+    -D ENV_ALPHA4  
+    -D __FPU_PRESENT=1
+    -mfloat-abi=hard
+    -mfpu=fpv4-sp-d16
 
 [env:Alpha3]
 extends = env:HC32F460C_ASD_HC_V1_5
-build_flags   = -D ENV_ALPHA3  
+build_flags = 
+    -D ENV_ALPHA3  
+    -D __FPU_PRESENT=1
+    -mfloat-abi=hard
+    -mfpu=fpv4-sp-d16
 
 [env:Charlie]
 extends = env:HC32F460C_ASD_HC_V4_1
-build_flags   = -D ENV_CHARLIE
-
+build_flags = 
+    -D ENV_CHARLIE  
+    -D __FPU_PRESENT=1
+    -mfloat-abi=hard
+    -mfpu=fpv4-sp-d16
 
 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = Alpha3
+default_envs = Alpha4
 ; default_envs = Charlie
 
 include_dir  = Marlin


### PR DESCRIPTION
1. Applied differentiated handling for alpha4 configuration as requested by Alex.

2. Calibrated linear advance value for alpha4 to 0.02.

3. Calibrated PID values for alpha4's hotend.

4. Confirmed that fade should be disabled for better surface quality, or alternatively set fade to 90.

5. Rewrote the FPU enablement section; verified correct functionality via disassembly using arm-none-eabi-objdump -d planner.cpp.o | Select-String "__aeabi_fmul|vmul".